### PR TITLE
Update Quick-Start-Guide.md (Added recommendation to get Metadata API credentials)

### DIFF
--- a/romm.wiki/Quick-Start-Guide.md
+++ b/romm.wiki/Quick-Start-Guide.md
@@ -16,6 +16,9 @@ This guide will assume that you already have the following done, if not - stop h
 * A MobyGames account (optional)
 * Your Roms organized in the correct format
 
+> [!CAUTION]
+> Not setting up RomM with a metadata API will work for basic operation but can cause issues with, for instance, the Playnite Plugin. It is recommended to setup IGDB (or MobyGames) APIs to counter issues whilst setting RomM up.
+
 #### Twitch and MobyGames API Keys
 
 Head over to [API key docs](https://github.com/rommapp/romm/wiki/Generate-API-Keys) to get your Twitch and/or MobyGames keys, then come back here


### PR DESCRIPTION
I had some issue as it relates to RomM and the Playnite plugin in particular. 

This was discussed on the Discord as can be seen here: https://discord.com/channels/1138838206532554853/1335632063998595122

I was made aware that my setup, which lacked API credentials for both IGDB and MobyGames, wasn't very normal. In my defense, I was having other issues and tried to remove them, but I also wasn't really made aware they were as essential as they appeared to have been.

Thusly, I wanted to add a warning that beginners really should have some metadata API credentials. I can't imagine IGDB uniquely would've solved my problem and that MobyGames would've done the deed as well, but maybe that's speculation.